### PR TITLE
Fix conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
 - linux
 env:
   matrix:
-  - TRAVIS_PYTHON_VERSION="2.7"
   - TRAVIS_PYTHON_VERSION="3.6"
   - TRAVIS_PYTHON_VERSION="3.7"
   global:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pymt_ecsimplesnow
   commands:
     - config_file=$(mmd-stage ECSimpleSnow . > MANIFEST && mmd-query ECSimpleSnow --var=run.config_file.path)
-    - bmi-test pymt_ecsimplesnow.bmi:ECSimpleSnow --config-file=$config_file --manifest=MANIFEST -v
+    - bmi-test pymt_ecsimplesnow.bmi:ECSimpleSnow --config-file=$config_file --manifest=MANIFEST -v --bmi-version=1.0
 
 about:
   summary: Python package that wraps the ecsimplesnow BMI.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,6 @@
-{% set data = load_setup_py_data() %}
-
 package:
   name: "pymt_ecsimplesnow"
-  version: {{ data.get('version') }}
+  version: "0.2"
 
 source:
   path: ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
+    - bmi-fortran=1.2 
+    - ecsimplesnow 
   host:
     - python
     - pip


### PR DESCRIPTION
This PR modifies the cookiecutter-generated conda recipe so that the project builds on macOS and Linux. 

I also removed the Python 2.7 build from Travis CI.