### PR TITLE
Fix build for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 - linux
 env:
   matrix:
+  - TRAVIS_PYTHON_VERSION="2.7"
   - TRAVIS_PYTHON_VERSION="3.6"
   - TRAVIS_PYTHON_VERSION="3.7"
   global:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ ext_modules = [
         ["pymt_ecsimplesnow/lib/ecsimplesnow.pyx"],
         libraries=libraries + ["bmisnowf"],
         extra_objects=['pymt_ecsimplesnow/lib/bmi_interoperability.o'],
-        **common_flags,
+        **common_flags
     ),
 ]
 


### PR DESCRIPTION
This PR fixes a error when building with Python 2.7. It also reactivates building and testing with Python 2.7 on Travis CI.