### PR TITLE
Build on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
 - linux
 env:
   matrix:
-  - TRAVIS_PYTHON_VERSION="2.7"
   - TRAVIS_PYTHON_VERSION="3.6"
   - TRAVIS_PYTHON_VERSION="3.7"
   global:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ def build_interoperability():
     cmd = []
     cmd.append(compiler.compiler_f90[0])
     cmd.append(compiler.compile_switch)
-    cmd.append('-fPIC')
+    if sys.platform.startswith("win") is False:
+        cmd.append("-fPIC")
     for include_dir in common_flags['include_dirs']:
         if os.path.isabs(include_dir) is False:
             include_dir = os.path.join(sys.prefix, "include", include_dir)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ common_flags = {
 libraries = [
 ]
 
+# Locate directories under Windows %LIBRARY_PREFIX%.
+if sys.platform.startswith("win"):
+    common_flags["include_dirs"].append(os.path.join(sys.prefix, "Library", "include"))
+    common_flags["library_dirs"].append(os.path.join(sys.prefix, "Library", "lib"))
+
 ext_modules = [
     Extension(
         "pymt_ecsimplesnow.lib.ecsimplesnow",


### PR DESCRIPTION
This PR updates the package to build on Windows. The key issue is locating the standard install directories, which are under a `Library` directory on Windows; e.g., the include directory is `%PREFIX%\Library\include`.

Also stopped building on Python 2.7 on Travis CI.