### PR TITLE
Force the flang compiler on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,15 @@ pymt_components = [(
 ]
 
 
+def get_fcompiler():
+    compiler=None
+    if sys.platform.startswith("win"):
+        compiler="flang"
+    return new_fcompiler(compiler=compiler)
+
+
 def build_interoperability():
-    compiler = new_fcompiler()
+    compiler = get_fcompiler()
     compiler.customize()
 
     cmd = []


### PR DESCRIPTION
Force the identification of the Fortran compiler on Windows; otherwise, it's not found correctly when building on conda-forge.