### PR TITLE
Try to fix conda-forge build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
 - linux
 env:
   matrix:
-  - TRAVIS_PYTHON_VERSION="3.6"
-  - TRAVIS_PYTHON_VERSION="3.7"
+  - TRAVIS_PYTHON_VERSION="3.*"
   global:
   - CONDA_PREFIX=$HOME/miniconda
   - MINICONDA_URL_BASE="https://repo.anaconda.com/miniconda/Miniconda3-latest"

--- a/pymt_ecsimplesnow/lib/bmi_interoperability.f90
+++ b/pymt_ecsimplesnow/lib/bmi_interoperability.f90
@@ -3,7 +3,7 @@
 !
 module bmi_interoperability
 
-  use, intrinsic :: iso_c_binding
+  use iso_c_binding
   use bmif_1_2
   use bmisnowf
 


### PR DESCRIPTION
In this PR, I'm trying to fix the [broken Windows builds](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=135121&view=logs&j=e5cdccbf-4751-5a24-7406-185c9d30d021&t=d66ed8ca-07ff-5419-c5d1-5e21fa500bb4) on conda-forge. I'm playing a hunch by not using the `intrinsic` keyword when importing the `iso_c_binding` module. This module is built into the gfortran library (it's intrinsic!), but perhaps not with flang, which is the conda Fortran compiler on Windows.

My evidence: an actual "iso_c_binding.mod" file is added to my designated include directory when I build this project on Windows.

Also note: I can build this project manually on Windows. It also builds in Appveyor. It only fails in Azure. It's frustrating that I can't test the Azure build somehow.

cc @mcflugen because this is an interesting little puzzle.